### PR TITLE
Fix crash when task didnt print anything

### DIFF
--- a/aocweb/submitter.go
+++ b/aocweb/submitter.go
@@ -33,6 +33,10 @@ func postAnswer(day int, year int, task int, solution string) (string, error) {
 }
 
 func Submit(day int, year int, task int, solution string) error {
+	if solution == "" {
+		return utils.AOCCLIError("Can't submit empty answer!")
+	}
+
 	result, err := postAnswer(day, year, task, solution)
 	if err != nil {
 		return utils.AOCCLIError("Error submitting answer!").DebugInfo("submitter", err.Error())

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -118,7 +118,13 @@ func runTask(day int, task int, executionDetails utils.ExecutionDetails, executi
 	} else {
 		cli.ToPrintf("Task %d failed execution after %s with exit code %d", task, result.executionDuration.Truncate(10000), result.exitCode).PrintError()
 	}
-	return result.stdout
+
+	if len(result.stdout) == 0 {
+		cli.ToPrint("Your code didn't output anything!").PrintWarning()
+		return []string{""}
+	} else {
+		return result.stdout
+	}
 }
 
 func SolveDay(year int, day int, task int, languageObject Language) []string {


### PR DESCRIPTION
Avoid the CLI crashing when the task didnt print anything, and avoid submitting empty results to not send unnecessary requests.