### PR TITLE
Improve output

### DIFF
--- a/output/spinner.go
+++ b/output/spinner.go
@@ -10,12 +10,14 @@ type Spinner struct {
 	_frame   int
 	_message string
 	_stop    bool
+	_time    int
 }
 
 func (s *Spinner) Run(message string) {
 	s._stop = false
 	s._frame = 0
 	s._message = message
+	s._time = 0
 
 	go s.draw()
 }
@@ -23,12 +25,14 @@ func (s *Spinner) Run(message string) {
 func (s *Spinner) toString() string {
 	frames := strings.Split("⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏", "")
 	s._frame = (s._frame + 1) % len(frames)
-	return fmt.Sprintf("%s %s", frames[s._frame], s._message)
+	var formattedTime, _ = time.ParseDuration(fmt.Sprintf("%dms", s._time))
+	return fmt.Sprintf("%s %s (%s elapsed)", frames[s._frame], s._message, formattedTime.Truncate(10000).String())
 }
 
 func (s *Spinner) draw() {
 	for !s._stop {
 		ToPrint(s.toString()).NewLine(false).Print()
+		s._time += 100
 		time.Sleep(100 * time.Millisecond)
 	}
 }

--- a/output/spinner.go
+++ b/output/spinner.go
@@ -7,26 +7,32 @@ import (
 )
 
 type Spinner struct {
-	_frame   int
-	_message string
-	_stop    bool
-	_time    int
+	_frame    int
+	_message  string
+	_stop     bool
+	_time     int
+	_showTime bool
 }
 
-func (s *Spinner) Run(message string) {
+func (s *Spinner) Run(message string, showTime bool) {
 	s._stop = false
 	s._frame = 0
 	s._message = message
 	s._time = 0
+	s._showTime = showTime
 
 	go s.draw()
 }
 
 func (s *Spinner) toString() string {
-	frames := strings.Split("⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏", "")
+	frames := strings.Split("⠋⠙⠸⠼⠴⠦⠧⠇⠏", "")
 	s._frame = (s._frame + 1) % len(frames)
-	var formattedTime, _ = time.ParseDuration(fmt.Sprintf("%dms", s._time))
-	return fmt.Sprintf("%s %s (%s elapsed)", frames[s._frame], s._message, formattedTime.Truncate(10000).String())
+	result := fmt.Sprintf("%s %s", frames[s._frame], s._message)
+	if s._showTime {
+		var formattedTime, _ = time.ParseDuration(fmt.Sprintf("%dms", s._time))
+		return fmt.Sprintf("%s (%s elapsed)", result, formattedTime.Truncate(10000).String())
+	}
+	return result
 }
 
 func (s *Spinner) draw() {

--- a/output/spinner.go
+++ b/output/spinner.go
@@ -25,7 +25,7 @@ func (s *Spinner) Run(message string, showTime bool) {
 }
 
 func (s *Spinner) toString() string {
-	frames := strings.Split("⠋⠙⠸⠼⠴⠦⠧⠇⠏", "")
+	frames := strings.Split("⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏", "")
 	s._frame = (s._frame + 1) % len(frames)
 	result := fmt.Sprintf("%s %s", frames[s._frame], s._message)
 	if s._showTime {

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -116,7 +116,7 @@ func prepareTask(year int, day int, task int, lang Language) {
 
 func runTask(day int, task int, executionDetails utils.ExecutionDetails, executionDirectory string) []string {
 	s := cli.Spinner{}
-	s.Run(fmt.Sprintf("Running day %d task %d", day, task))
+	s.Run(fmt.Sprintf("Running day %d task %d", day, task), true)
 	result := runCommand(true, executionDetails, executionDirectory, &s)
 	s.Stop()
 	if result.exitCode == 0 {

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -60,7 +60,7 @@ func runCommand(streamOutput bool, toRun utils.ExecutionDetails, workingDirector
 	for scanner.Scan() {
 		m := scanner.Text()
 		if streamOutput {
-			cli.ToPrint(m).Color(color.FgCyan).Italic().Print()
+			cli.ToPrintf("$ %s", m).Color(color.FgCyan).Italic().Print()
 			if s != nil {
 				s.Reprint()
 			}
@@ -73,7 +73,7 @@ func runCommand(streamOutput bool, toRun utils.ExecutionDetails, workingDirector
 	for errScanner.Scan() {
 		m := errScanner.Text()
 		if streamOutput {
-			cli.ToPrint(m).Color(color.FgCyan).Italic().Print()
+			cli.ToPrintf("$ %s", m).Color(color.FgCyan).Italic().Print()
 			if s != nil {
 				s.Reprint()
 			}


### PR DESCRIPTION
This PR improves two parts of the cli output:
- Adds the currently running time to the output of the spinner, so the time the script is already running is always displayed (#16):
    `⠹ Running day 1 task 1 (1.2s elapsed)`
- Adds a prefix to all outputs from the script to visually enhance the output. This is largely subjective, and currently inspired by the docker build cli, which uses a similar prefix.
    ```
    $ SOME SCRIPT OUTPUT HERE
    Task 1 finished successfully after 2.013s
    ```